### PR TITLE
Added a "Material" Page and Fixed iOS page placement

### DIFF
--- a/Gastropod.Android/MainActivity.cs
+++ b/Gastropod.Android/MainActivity.cs
@@ -19,7 +19,7 @@ namespace Gastropod.Droid
 
             base.OnCreate(bundle);
 
-            global::Xamarin.Forms.Forms.SetFlags("Shell_Experimental");
+            global::Xamarin.Forms.Forms.SetFlags("Visual_Experimental", "Shell_Experimental");
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
         }

--- a/Gastropod.iOS/AppDelegate.cs
+++ b/Gastropod.iOS/AppDelegate.cs
@@ -22,7 +22,7 @@ namespace Gastropod.iOS
         //
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
-            global::Xamarin.Forms.Forms.SetFlags("Shell_Experimental");
+            global::Xamarin.Forms.Forms.SetFlags("Visual_Experimental", "Shell_Experimental");
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
 

--- a/Gastropod/Pages/ActivityPage.xaml
+++ b/Gastropod/Pages/ActivityPage.xaml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
-             Title="Activity" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
+             Title="Activity" 
              x:Class="Gastropod.ActivityPage">
     <StackLayout>
         <!-- Place new controls here -->

--- a/Gastropod/Pages/FeedPage.xaml
+++ b/Gastropod/Pages/FeedPage.xaml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
              x:Class="Gastropod.FeedPage">
     <ContentPage.Content>
         <ListView x:Name="ItemsListView" ItemsSource="{Binding Items}" VerticalOptions="FillAndExpand" HasUnevenRows="true">

--- a/Gastropod/Pages/MainPage.xaml
+++ b/Gastropod/Pages/MainPage.xaml
@@ -2,6 +2,8 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              xmlns:local="clr-namespace:Gastropod"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
              Title="Store Home"
              x:Class="Gastropod.MainPage">
     <FlexLayout AlignItems="Center" AlignContent="Center" Direction="Column">

--- a/Gastropod/Pages/MaterialPage.xaml
+++ b/Gastropod/Pages/MaterialPage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:local="clr-namespace:Gastropod"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
+             Visual="Material"
+             Title="Material"
+             x:Class="Gastropod.MaterialPage">
+    <ContentPage.Content>
+        <StackLayout Margin="10">
+            <Label Text="Page using Visual=&quot;Material&quot;" />
+            <Entry Text="Material Entry"/>
+            <Button Text="Material Button" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Gastropod/Pages/MaterialPage.xaml.cs
+++ b/Gastropod/Pages/MaterialPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Gastropod
+{
+    public partial class MaterialPage : ContentPage
+    {
+        public MaterialPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Gastropod/Pages/NotificationsPage.xaml
+++ b/Gastropod/Pages/NotificationsPage.xaml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
              Title="Notifications"
              x:Class="Gastropod.NotificationsPage">
     <StackLayout>

--- a/Gastropod/Pages/UpdatesPage.xaml
+++ b/Gastropod/Pages/UpdatesPage.xaml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
              Title="Updates"
              x:Class="Gastropod.UpdatesPage">
     <StackLayout>

--- a/Gastropod/Shell.xaml
+++ b/Gastropod/Shell.xaml
@@ -48,6 +48,10 @@
     <ShellItem Route="single" Title="Single Page" FlyoutIcon="iconXamarin.png">
         <ShellContent Route="home" Title="Home" Icon="iconXamarin.png" ContentTemplate="{DataTemplate local:MainPage}" />
     </ShellItem>
+    
+    <ShellItem Route="material" Title="Material Page" FlyoutIcon="iconXamarin.png">
+        <ShellContent Route="materialpage" Title="Material" Icon="iconXamarin.png" ContentTemplate="{DataTemplate local:MaterialPage}" />
+    </ShellItem>
 
     <ShellItem Route="toptabs" Title="Top Tabs" FlyoutIcon="iconXamarin.png" Style="{StaticResource QuaternaryShell}">
         <ShellSection Route="activity" Title="Activity" Icon="iconXamarin.png" >


### PR DESCRIPTION
Pages with a single line inside a StackLayout were not showing cause the page was starting from the top of the device and not considering the Navigation Bar (do you know that's a bug or by design? Android behaves different)
Basically added 
```
xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
             ios:Page.UseSafeArea="true"
```
to all pages.

Also create a page showing the use of Visual="Material". I notice that on the GitHub issue about Steel there a "MaterialShell", but I couldn't find any other documentation or reference to it, so I failed to make that work. 